### PR TITLE
Typefu 2019

### DIFF
--- a/Halmak.tfl
+++ b/Halmak.tfl
@@ -1,0 +1,290 @@
+{
+  "id": "custom-3ae4753a-61a2-44b0-9ca5-b81bed0df8b4",
+  "name": "Halmak",
+  "version": 1,
+  "keys": {
+    "KeyQ": {
+      "default": {
+        "base": "w",
+        "shift": "W"
+      }
+    },
+    "Backquote": {
+      "default": {
+        "base": "`",
+        "shift": "~"
+      }
+    },
+    "KeyW": {
+      "default": {
+        "base": "l",
+        "shift": "L"
+      }
+    },
+    "KeyE": {
+      "default": {
+        "base": "r",
+        "shift": "R"
+      }
+    },
+    "KeyR": {
+      "default": {
+        "base": "b",
+        "shift": "B"
+      }
+    },
+    "KeyT": {
+      "default": {
+        "base": "z",
+        "shift": "Z"
+      }
+    },
+    "KeyY": {
+      "default": {
+        "base": ";",
+        "shift": ":"
+      }
+    },
+    "KeyU": {
+      "default": {
+        "base": "q",
+        "shift": "Q"
+      }
+    },
+    "KeyI": {
+      "default": {
+        "base": "u",
+        "shift": "U"
+      }
+    },
+    "KeyO": {
+      "default": {
+        "base": "d",
+        "shift": "D"
+      }
+    },
+    "KeyP": {
+      "default": {
+        "base": "j",
+        "shift": "J"
+      }
+    },
+    "BracketLeft": {
+      "default": {
+        "base": "[",
+        "shift": "{"
+      }
+    },
+    "BracketRight": {
+      "default": {
+        "base": "]",
+        "shift": "}"
+      }
+    },
+    "Backslash": {
+      "default": {
+        "base": "\\",
+        "shift": "|"
+      }
+    },
+    "KeyA": {
+      "default": {
+        "base": "s",
+        "shift": "S"
+      }
+    },
+    "KeyS": {
+      "default": {
+        "base": "h",
+        "shift": "H"
+      }
+    },
+    "KeyD": {
+      "default": {
+        "base": "n",
+        "shift": "N"
+      }
+    },
+    "KeyF": {
+      "default": {
+        "base": "t",
+        "shift": "T"
+      }
+    },
+    "KeyG": {
+      "default": {
+        "base": ",",
+        "shift": "("
+      }
+    },
+    "KeyH": {
+      "default": {
+        "base": ".",
+        "shift": ")"
+      }
+    },
+    "Digit0": {
+      "default": {
+        "base": "0",
+        "shift": ">"
+      }
+    },
+    "Digit1": {
+      "default": {
+        "base": "1",
+        "shift": "!"
+      }
+    },
+    "Digit2": {
+      "default": {
+        "base": "2",
+        "shift": "@"
+      }
+    },
+    "Digit3": {
+      "default": {
+        "base": "3",
+        "shift": "#"
+      }
+    },
+    "Digit4": {
+      "default": {
+        "base": "4",
+        "shift": "$"
+      }
+    },
+    "Digit5": {
+      "default": {
+        "base": "5",
+        "shift": "%"
+      }
+    },
+    "Digit6": {
+      "default": {
+        "base": "6",
+        "shift": "^"
+      }
+    },
+    "Digit7": {
+      "default": {
+        "base": "7",
+        "shift": "&"
+      }
+    },
+    "Digit8": {
+      "default": {
+        "base": "8",
+        "shift": "*"
+      }
+    },
+    "Digit9": {
+      "default": {
+        "base": "9",
+        "shift": "<"
+      }
+    },
+    "Minus": {
+      "default": {
+        "base": "-",
+        "shift": "_"
+      }
+    },
+    "Equal": {
+      "default": {
+        "base": "=",
+        "shift": "+"
+      }
+    },
+    "KeyZ": {
+      "default": {
+        "base": "f",
+        "shift": "F"
+      }
+    },
+    "KeyX": {
+      "default": {
+        "base": "m",
+        "shift": "M"
+      }
+    },
+    "KeyC": {
+      "default": {
+        "base": "v",
+        "shift": "V"
+      }
+    },
+    "KeyV": {
+      "default": {
+        "base": "c",
+        "shift": "C"
+      }
+    },
+    "KeyB": {
+      "default": {
+        "base": "/",
+        "shift": "?"
+      }
+    },
+    "KeyN": {
+      "default": {
+        "base": "g",
+        "shift": "G"
+      }
+    },
+    "KeyM": {
+      "default": {
+        "base": "p",
+        "shift": "P"
+      }
+    },
+    "Comma": {
+      "default": {
+        "base": "x",
+        "shift": "X"
+      }
+    },
+    "Period": {
+      "default": {
+        "base": "k",
+        "shift": "K"
+      }
+    },
+    "Slash": {
+      "default": {
+        "base": "y",
+        "shift": "Y"
+      }
+    },
+    "KeyJ": {
+      "default": {
+        "base": "a",
+        "shift": "A"
+      }
+    },
+    "KeyK": {
+      "default": {
+        "base": "e",
+        "shift": "E"
+      }
+    },
+    "KeyL": {
+      "default": {
+        "base": "o",
+        "shift": "O"
+      }
+    },
+    "Semicolon": {
+      "default": {
+        "base": "i",
+        "shift": "I"
+      }
+    },
+    "Quote": {
+      "default": {
+        "base": "'",
+        "shift": "\""
+      }
+    }
+  },
+  "description": "The ultimate keyboard layout - designed by an evolutionary AI. More efficient than QWERTY, Dvorak, Colemak, and Workman."
+}

--- a/README.md
+++ b/README.md
@@ -4,30 +4,13 @@ This is the [halmak keyboard layout](https://github.com/MadRabbit/halmak)
 support module for the [TypeFu app](http://type-fu.com), which is a really
 nice touch-typing training app.
 
-__NOTE__: this is an unofficial support for the layout. it is totally safe, but
-a DIY thing, so be warned.
-
 ## How To Install
 
-Type Fu is a hybrid app, it is actually build in javascript and stuff. So, to
-install the layout support do the following:
-
-```
-cd somewhere/tmp
-git clone https://github.com/MadRabbit/halmak-typefu.git
-cd /Applications/Type\ Fu.app/Contents/Resources/frontend/
-cp somewhere/tmp/typefu-rockstar-support/halmak.json assets/layouts
-edit frontend.js
-```
-
-So, basically you need to copy the [halmak.json](halmak.json) config into
-the `assets/layout` folder in the TypeFu guts. Then open up the `frontend.js`
-file and find the `workman` word. You will see an array of supported keyboard
-layouts. At the end of the list add `{id: "halmak", label: "Halmak"}` to
-register the new layout.
-
-After that just restart TypeFu, go into its preferences and you should see the
-`Halmak` option in the list.
+* Download the file `Halmak.tfl`.
+* Open Preferences in TypeFu.
+* Go to `Keyboard`.
+* Next to the `Functional` setting, click the drop-down and choose `Import from File`.
+* Select the `Halmak.tfl` file that you downloaded.
 
 Happy training!
 


### PR DESCRIPTION
Settings for TypeFu in 2019. I downloaded the app from the Mac App Store, and the older instructions don't work. 

I created the Halmak layout in TypeFu and exported it. Fixes #1 